### PR TITLE
context for func StartServer

### DIFF
--- a/docker/just_docker-compose_example.yml
+++ b/docker/just_docker-compose_example.yml
@@ -1,0 +1,24 @@
+version: '3'
+services:
+  nginx:
+    image: nginx:alpine
+    restart: always
+    volumes:
+      - "./nginx.conf:/etc/nginx/conf.d/default.conf"
+
+  mailhog:
+    image: jcalonso/mailhog
+    restart: always
+    ports:
+      - "8025:8025"
+  litecart:
+    container_name: litecart
+    restart: unless-stopped
+    ports:
+      - 8080:8080
+    volumes:
+      - ./lc_base:/lc_base
+      - ./lc_digitals:/lc_digitals
+      - ./lc_uploads:/lc_uploads
+      - ./site:/site
+    image: shurco/litecart:latest


### PR DESCRIPTION
## Description

added a context for processing the termination signal. now the server starts in a separate go routine and terminates more correctly

- [ ] Bug fix (non-breaking change which fixes an issue) - Optimization

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I tried to make my code as fast as possible with as few allocations as possible
