### PR TITLE
feat: add dummy payment method

### DIFF
--- a/internal/handlers/private/setting.go
+++ b/internal/handlers/private/setting.go
@@ -103,6 +103,8 @@ func GetSetting(c *fiber.Ctx) error {
 		section, err = db.GetSettingByGroup(c.Context(), &models.Paypal{})
 	case "spectrocoin":
 		section, err = db.GetSettingByGroup(c.Context(), &models.Spectrocoin{})
+	case "dummy":
+		section, err = db.GetSettingByGroup(c.Context(), &models.Dummy{})
 	case "mail":
 		section, err = db.GetSettingByGroup(c.Context(), &models.Mail{})
 	default:
@@ -146,6 +148,8 @@ func UpdateSetting(c *fiber.Ctx) error {
 		request = &models.Paypal{}
 	case "spectrocoin":
 		request = &models.Spectrocoin{}
+	case "dummy":
+		request = &models.Dummy{}
 	case "webhook":
 		request = &models.Webhook{}
 	case "mail":

--- a/internal/models/setting.go
+++ b/internal/models/setting.go
@@ -105,12 +105,18 @@ func (v Spectrocoin) Validate() error {
 	)
 }
 
+// Dummy is ...
+type Dummy struct {
+	Active bool `json:"active"`
+}
+
 // PaymentSystem is ...
 type PaymentSystem struct {
 	Active      []string    `json:"active"`
 	Stripe      Stripe      `json:"stripe"`
 	Paypal      Paypal      `json:"paypal"`
 	Spectrocoin Spectrocoin `json:"spectrocoin"`
+	Dummy       Dummy       `json:"dummy"`
 }
 
 // Validate is ...

--- a/internal/queries/cart.go
+++ b/internal/queries/cart.go
@@ -23,7 +23,7 @@ type CartQueries struct {
 func (q *CartQueries) PaymentList(ctx context.Context) (map[string]bool, error) {
 	payments := map[string]bool{}
 	keys := []any{
-		"stripe_active", "paypal_active", "spectrocoin_active",
+		"stripe_active", "paypal_active", "spectrocoin_active", "dummy_active",
 	}
 
 	query := fmt.Sprintf("SELECT key, value FROM setting WHERE key IN (%s)", strings.Repeat("?, ", len(keys)-1)+"?")

--- a/internal/queries/setting.go
+++ b/internal/queries/setting.go
@@ -68,6 +68,10 @@ func (q *SettingQueries) GroupFieldMap(settings any) map[string]any {
 			"spectrocoin_private_key": &s.PrivateKey,
 			"spectrocoin_active":      &s.Active,
 		}
+	case *models.Dummy:
+		return map[string]any{
+			"dummy_active": &s.Active,
+		}
 	case *models.Webhook:
 		return map[string]any{
 			"webhook_url": &s.Url,

--- a/migrations/20251231064849_dummy.sql
+++ b/migrations/20251231064849_dummy.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+INSERT INTO setting VALUES ('dUmMyPaYm3ntAcT', 'dummy_active', 'false');
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DELETE FROM setting WHERE id = 'dUmMyPaYm3ntAcT';
+-- +goose StatementEnd

--- a/pkg/litepay/helper.go
+++ b/pkg/litepay/helper.go
@@ -105,6 +105,11 @@ func StatusPayment(system PaymentSystem, status string) Status {
 			"5": FAILED,    // expired, Payment was not received in time
 			"6": TEST,      // test, Test order
 		}
+
+	case DUMMY:
+		statusBase = map[string]Status{
+			"paid": PAID,
+		}
 	}
 
 	statusTmp := statusBase[status]

--- a/pkg/litepay/helper_test.go
+++ b/pkg/litepay/helper_test.go
@@ -115,6 +115,8 @@ func Test_status_payment(t *testing.T) {
 		{SPECTROCOIN, "5", FAILED},
 		{SPECTROCOIN, "6", TEST},
 		{SPECTROCOIN, "", FAILED},
+		{DUMMY, "paid", PAID},
+		{DUMMY, "", FAILED},
 	}
 
 	for _, tt := range cases {

--- a/pkg/litepay/provider.go
+++ b/pkg/litepay/provider.go
@@ -6,4 +6,5 @@ const (
 	STRIPE      PaymentSystem = "stripe"
 	PAYPAL      PaymentSystem = "paypal"
 	SPECTROCOIN PaymentSystem = "spectrocoin"
+	DUMMY       PaymentSystem = "dummy"
 )

--- a/pkg/litepay/provider_dummy.go
+++ b/pkg/litepay/provider_dummy.go
@@ -1,0 +1,43 @@
+package litepay
+
+import (
+	"fmt"
+	"strings"
+)
+
+type dummy struct {
+	Cfg
+	successURL string
+}
+
+func (c Cfg) Dummy() LitePay {
+	c.paymentSystem = DUMMY
+	c.currency = []string{"EUR", "USD", "GBP", "AUD", "CAD", "JPY", "CNY", "SEK"}
+	return &dummy{
+		Cfg:        c,
+		successURL: c.successURL,
+	}
+}
+
+func (c *dummy) Pay(cart Cart) (*Payment, error) {
+	var amountTotal int
+	for _, item := range cart.Items {
+		amountTotal += item.PriceData.UnitAmount * item.Quantity
+	}
+
+	checkout := &Payment{
+		AmountTotal:   amountTotal,
+		Currency:      strings.ToUpper(cart.Currency),
+		Status:        PAID,
+		URL:           fmt.Sprintf("%s/?payment_system=%s&cart_id=%s", c.successURL, c.paymentSystem, cart.ID),
+		PaymentSystem: c.paymentSystem,
+	}
+
+	return checkout, nil
+}
+
+func (c *dummy) Checkout(payment *Payment, session string) (*Payment, error) {
+	payment.Status = PAID
+	payment.MerchantID = "dummy_" + payment.CartID
+	return payment, nil
+}


### PR DESCRIPTION
Fixes #246

## Summary
- Add dummy payment provider that always succeeds
- Integrate with existing payment system architecture (handlers, models, queries)
- Add migration to store dummy_active setting (defaults to false)
- Add tests for dummy payment status handling

## Use Case
Gift registries and other scenarios where always-succeeding payments are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)