### PR TITLE
🐛 fix(ci): publish mycart Docker image to Docker Hub

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -1,0 +1,50 @@
+name: Publish to Docker Hub
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v0.2.8)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Mirror GHCR image to Docker Hub
+        env:
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TAG}" ]; then
+            echo "Release tag is required"
+            exit 1
+          fi
+
+          SOURCE="ghcr.io/shurco/mycart:${TAG}"
+          echo "Mirroring ${SOURCE} to shurco/mycart"
+
+          docker buildx imagetools create \
+            --tag "shurco/mycart:${TAG}" \
+            --tag "shurco/mycart:latest" \
+            "${SOURCE}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
           fetch-depth: 0
       - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: network=host
       - uses: docker/login-action@v4
         with:
           registry: ghcr.io

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -86,31 +86,9 @@ changelog:
       order: 9999
 
 dockers_v2:
-  - id: dockerhub
+  - id: release
     images:
       - 'shurco/mycart'
-    tags:
-      - 'v{{ .Version }}'
-      - 'latest'
-    platforms:
-      - linux/amd64
-      - linux/arm64
-    dockerfile: Dockerfile.goreleaser
-    flags:
-      - '--pull'
-    labels:
-      'io.artifacthub.package.readme-url': 'https://raw.githubusercontent.com/shurco/mycart/main/README.md'
-      'io.artifacthub.package.maintainers': '[{"name":"Dmitry Shurco"}]'
-      'io.artifacthub.package.license': 'MIT'
-      'org.opencontainers.image.description': '🛒 myCart - shopping-cart in 1 file'
-      'org.opencontainers.image.created': '{{.Date}}'
-      'org.opencontainers.image.name': '{{.ProjectName}}'
-      'org.opencontainers.image.revision': '{{.FullCommit}}'
-      'org.opencontainers.image.version': '{{.Version}}'
-      'org.opencontainers.image.source': '{{.GitURL}}'
-
-  - id: ghcr
-    images:
       - 'ghcr.io/shurco/mycart'
     tags:
       - 'v{{ .Version }}'
@@ -119,8 +97,10 @@ dockers_v2:
       - linux/amd64
       - linux/arm64
     dockerfile: Dockerfile.goreleaser
+    sbom: false
     flags:
       - '--pull'
+      - '--provenance=false'
     labels:
       'io.artifacthub.package.readme-url': 'https://raw.githubusercontent.com/shurco/mycart/main/README.md'
       'io.artifacthub.package.maintainers': '[{"name":"Dmitry Shurco"}]'


### PR DESCRIPTION
Changes made in this commit:
- Modified: .github/workflows/release.yml, .goreleaser.yml
- Added: .github/workflows/docker-hub-publish.yml

Key changes:
- Consolidate dockers_v2 into a single build for Docker Hub and GHCR
- Disable SBOM and provenance attestations for Docker Hub compatibility
- Configure buildx driver-opts in the release workflow
- Add fallback workflow to mirror GHCR images to Docker Hub

Fixes the missing shurco/mycart repository on Docker Hub after the litecart to myCart rename. GHCR already published images; Docker Hub did not receive updates since v0.2.7.

Closes #335

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. 
Explain the *details* for making this change. What existing problem does the pull request solve?

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [ ] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/